### PR TITLE
refines zip codes in parser

### DIFF
--- a/geoclient-parser/src/main/resources/zip.properties
+++ b/geoclient-parser/src/main/resources/zip.properties
@@ -1,3 +1,4 @@
+# Revised 20200124 see commit message for details and procedure
 00083=MANHATTAN
 07305=MANHATTAN
 10000=MANHATTAN
@@ -133,6 +134,7 @@
 10461=BRONX
 10462=BRONX
 10463=BRONX
+10463=MANHATTAN
 10464=BRONX
 10465=BRONX
 10466=BRONX
@@ -213,6 +215,7 @@
 11367=QUEENS
 11368=QUEENS
 11369=QUEENS
+11370=BRONX
 11370=QUEENS
 11371=QUEENS
 11372=QUEENS
@@ -222,6 +225,7 @@
 11377=QUEENS
 11378=QUEENS
 11379=QUEENS
+11385=BROOKLYN
 11385=QUEENS
 11411=QUEENS
 11412=QUEENS
@@ -254,266 +258,3 @@
 11694=QUEENS
 11695=QUEENS
 11697=QUEENS
-#
-# -- 1. Remove duplicate zipcode=borough key values
-# --    Reduces 263 pairs to 251
-# --    We are left with 3 zips that cross boroughs and should be ogled
-# --    10463=(BRONX|MANHATTAN) A bit of Marble Hill. Give to BX where most of zip is
-# --    11370=(BRONX|QUEENS)  Rikers island, zip is predominantly in Queens
-# --    11693=(BROOKLYN|QUEENS) This is Queens in Jamaica Bay, typical GIS shenanigans
-#
-# with zip_properties_geoclient as (
-#    select '00083=MANHATTAN' as keyval from dual union
-#    select '10001=MANHATTAN' from dual union
-#    select '10002=MANHATTAN' from dual union
-# SNIP!
-#    select '11693=QUEENS' from dual union
-#    select '11694=QUEENS' from dual union
-#    select '11697=QUEENS' from dual
-# ) select distinct keyval
-#  from
-#        zip_properties_geoclient
-#  order by 1;
-#
-#   -- 2. NYC Street Centerline (CSCL) database comparison using cscl_pub.zipcode
-#   --    Yields nothing new, appears to be the same dataset that produced the
-#   -     original geoclient parser info
-#
-# with keyvals as (
-#    select '00083=MANHATTAN' as keyval from dual union
-#    select '10001=MANHATTAN' from dual union
-#    select '10002=MANHATTAN' from dual union
-# SNIP!
-#    select '11694=QUEENS' from dual union
-#    select '11697=QUEENS' from dual
-# ) select keyval
-#    from
-#        keyvals
-#    minus
-#    select distinct to_char(zip_code) || '=' || DECODE(county, 'New York','MANHATTAN','Bronx','BRONX','Kings', 'BROOKLYN','Queens', 'QUEENS','Richmond','STATEN ISLAND') AS keyval
-#    from
-#        cscl_pub.zipcode
-#union
-#    select to_char(zip_code) || '=' || DECODE(county, 'New York','MANHATTAN','Bronx','BRONX','Kings', 'BROOKLYN','Queens', 'QUEENS','Richmond','STATEN ISLAND') AS keyval
-#    from
-#        cscl_pub.zipcode
-#    minus
-#    select keyval
-#    from
-#        keyvals;
-#
-# -- 3. Compare to all address points in CSCL
-# --    Yields 35 zip codes in geoclient properties that have no address point
-# --    34 are Manhattan Post Offices, all good, keep these
-# --    1 is the duplicate 11693=BROOKLYN This is a Queens zip code in
-# --    in Jamaica Bay that through typical GIS shenanigans, turning non-spatial
-# --    Zip codes into shapes results in some slopping into Brooklyn
-# --    11693=BROOKLYN - you are officially voted off the island
-# --
-# with keyvals as (
-#    select '00083=MANHATTAN' as keyval from dual union
-#    select '10001=MANHATTAN' from dual union
-# SNIP!
-#    select '11694=QUEENS' from dual union
-#    select '11697=QUEENS' from dual
-# ) select distinct TO_CHAR(zipcode) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval
-#     from
-#         cscl_pub.ADDRESSPOINT
-#     minus
-#     select keyval
-#     from
-#         keyvals
-# union
-#     select keyval
-#     from
-#         keyvals
-#     minus
-#     select distinct TO_CHAR(zipcode) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval
-#     from
-#         cscl_pub.ADDRESSPOINT;
-# --10041=MANHATTAN
-# --10043=MANHATTAN
-# --10045=MANHATTAN
-# --10047=MANHATTAN
-# --10103=MANHATTAN
-# --10104=MANHATTAN
-# --10105=MANHATTAN
-# --10110=MANHATTAN
-# --10112=MANHATTAN
-# --10119=MANHATTAN
-# --10120=MANHATTAN
-# --10122=MANHATTAN
-# --10123=MANHATTAN
-# --10151=MANHATTAN
-# --10155=MANHATTAN
-# --10158=MANHATTAN
-# --10162=MANHATTAN
-# --10165=MANHATTAN
-# --10166=MANHATTAN
-# --10167=MANHATTAN
-# --10169=MANHATTAN
-# --10170=MANHATTAN
-# --10171=MANHATTAN
-# --10172=MANHATTAN
-# --10173=MANHATTAN
-# --10174=MANHATTAN
-# --10175=MANHATTAN
-# --10176=MANHATTAN
-# --10177=MANHATTAN
-# --10178=MANHATTAN
-# --10203=MANHATTAN
-# --10271=MANHATTAN
-# --10285=MANHATTAN
-# --10286=MANHATTAN
-# --11693=BROOKLYN
-#
-# -- 4. Compare to all L_ZIP and R_ZIP in CSCL centerlines
-# --    Yields 3 new zips (Fresh Kills, Central Park, Fort Tilden)
-# --    And some detailed notes on questionable zip codes that I guess we should
-# --    keep.
-# -- First, these exist in CSCL centerlines, not in Geoclient parser
-# with keyvals as (
-#   select '00083=MANHATTAN' as keyval from dual union
-#   select '10001=MANHATTAN' from dual union
-# SNIP!
-#   select '11694=QUEENS' from dual union
-#   select '11697=QUEENS' from dual
-# )
-#  select keyval from (
-#      select distinct TO_CHAR(l_zip) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval from cscl_pub.CENTERLINE where l_zip is not null
-#      union
-#      select distinct TO_CHAR(r_zip) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval from cscl_pub.CENTERLINE where r_zip is not null
-# )
-# minus
-#  select keyval
-#       from keyvals;
-#-- exist in centerline not in geoclient
-#-- lets review these and add some to the geoclient parser!
-#--10000=MANHATTAN     -- Central Park! This is not a real zip code, like 00083. YES ADD
-#--10035=BRONX         -- Tiny segment of third ave bike bridge, rest of 10035 in MN. NO
-#--10037=BRONX         -- Large segment of third ave bike bridge, rest of 10035 in MN. NO
-#--10313=STATEN ISLAND -- Fresh Kills landfill. A real zip code.  OH YES ADD
-#--10400=BRONX         -- A few segments at the entrance of Rikers. Not a real zip code. No
-#--10451=MANHATTAN     -- 145 ST Bridge segment, rest of zip is in BX. No
-#--10453=MANHATTAN     -- A few segments of Washington St, rest of Zip in BX. No
-#--10454=MANHATTAN     -- A segment of Willis St, rest of Zip in BX. No
-#--11201=MANHATTAN     -- Greenway in Brooklyn Bridge Park.  It is technically in MN but the zip is BK. No
-#--11222=QUEENS        -- Bit of Pulaski Bridge.  Zip is in BK. No
-#--11234=QUEENS        -- Bit of Marine Parkway Bridge.  Zip is in BK. No
-#--11239=QUEENS        -- Bit of Belt Parkway. Zip is in BK. No
-#--11249=MANHATTAN     -- Bit of Williamsburg bridge.  Zip is in BK. No.
-#--11385=BROOKLYN      -- A few Ridgewood-adjacent alleys.  Zip in Queens. No
-#--11396=QUEENS        -- Not a real zip code.  Should be 113_69_. Nice, but no.
-#--11416=BROOKLYN      -- Segments on near Ozone Park border. Zip is in QN. No
-#--11693=BROOKLYN      -- This is that dumb Far Rockaway segment that GISed into BK. No
-#--11695=QUEENS        -- Fort Tilden, oh YES
-#
-# These exist in Geoclient parser, not in CSCL centerlines. All are OK
-# with keyvals as (
-#    select '00083=MANHATTAN' as keyval from dual union
-#    select '10001=MANHATTAN' from dual union
-# SNIP!
-#    select '11694=QUEENS' from dual union
-#    select '11697=QUEENS' from dual
-# )
-# select keyval
-#    from keyvals
-# minus
-# select keyval from (
-#     select distinct TO_CHAR(l_zip) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval from cscl_pub.CENTERLINE where l_zip is not null
-#     union
-#     select distinct TO_CHAR(r_zip) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval from cscl_pub.CENTERLINE where r_zip is not null
-# )
-#--
-#-- exist in geoclient not in centerline
-#--
-#--10043=MANHATTAN --Real PO in MN, OK
-#--10047=MANHATTAN --Non existent zip code, overlaps 10010.  But its pervasive in CSCL-derived products. OK
-#--10055=MANHATTAN --Real PO in MN. OK
-#--10081=MANHATTAN --Real PO in MN. OK
-#--10096=MANHATTAN --Non existent zip code. But its possibly pervasive in CSCL-derived products. OK
-#--10097=MANHATTAN --Non existent zip code. But its been pervasive. OK
-#--10104=MANHATTAN --Real PO in MN. OK
-#--10107=MANHATTAN --Real PO in MN. OK
-#--10115=MANHATTAN --Real PO in MN. OK
-#--10122=MANHATTAN --Real PO in MN. OK
-#--10123=MANHATTAN --Real PO in MN. OK
-#--10151=MANHATTAN --Real PO in MN. OK
-#--10153=MANHATTAN --Real PO in MN. OK
-#--10168=MANHATTAN --Real PO in MN. OK
-#--10169=MANHATTAN --Real PO in MN. OK
-#--10196=MANHATTAN --Non existent zip code. But its presumably pervasive. OK
-#--10203=MANHATTAN --Real PO in MN. OK
-#--10259=MANHATTAN --Real PO in MN. OK
-#--10260=MANHATTAN --Real PO in MN. OK
-#--10265=MANHATTAN --Real PO in MN. OK
-#--10270=MANHATTAN --Real PO in MN. OK
-#--10275=MANHATTAN --Real PO in MN. OK
-#--10285=MANHATTAN --Real PO in MN. OK
-#--10286=MANHATTAN --Real PO in MN. OK
-#--11096=QUEENS    --Territory in Far Rockaway that possibly uses a Nassau County zip
-#--11451=QUEENS    --York College, OK
-#
-# --5. Get Zip Code Tabulation Areas and see what we get
-# --     https://www2.census.gov/geo/tiger/TIGER2019/
-# --     https://data.cityofnewyork.us/City-Government/Borough-Boundaries/tqmj-j8zm
-# --     upload as sdo_geometry to master@giscmnt
-# -- Get ZCTA=BOROUGH combos that exist in census but not in Geoclient Parser
-#
-#select to_char(a.zcta5ce10) || '=' || UPPER(b.boroname), sdo_geom.relate(a.shape, 'mask=determine', b.shape, .0005)
-# with keyvals as
-#   (select '00083=MANHATTAN' as keyval from dual union
-#    select '10000=MANHATTAN' from dual union
-# SNIP!
-#    select '11695=QUEENS' from dual union
-#    select '11697=QUEENS' from dual)
-# select keyval from (
-#     select to_char(a.zcta5ce10) || '=' || to_char(UPPER(b.boroname)) as keyval
-#     from
-#        zctas a
-#       ,nybb b
-#     where
-#        sdo_relate(a.shape
-#                  ,b.shape
-#                  ,'mask=INSIDE+COVEREDBY+OVERLAPBDYINTERSECT+OVERLAPBDYDISJOINT') = 'TRUE'
-# )
-# minus
-# select to_char(keyval)
-# from
-#     keyvals;
-# --07002=STATEN ISLAND --NJ sliver bordering staten island, no
-# --07206=STATEN ISLAND --NJ sliver bordering staten island, no
-# --07305=MANHATTAN     --NJ zip that jokers in NJ will claim on Ellis Island. YES
-# --10004=BROOKLYN      --Roosevelt island sliver, no
-# --10199=MANHATTAN     --A real PO in MN.  YES
-# --10311=STATEN ISLAND --More Fresh Kills. YES
-# --10463=MANHATTAN     --Marble Hill, no
-# --10550=BRONX         --Westchester sliver, no
-# --10704=BRONX         --Westchester sliver, no
-# --10705=BRONX         --Westchester sliver, no
-# --10803=BRONX         --Westchester sliver, no
-# --11003=QUEENS        --Nassau sliver, no
-# --11020=QUEENS        --Nassau sliver, no
-# --11021=QUEENS        --Nassau sliver, no
-# --11042=QUEENS        --Nassau sliver, no
-# --11102=MANHATTAN     --Queens sliver Astoria, no
-# --11201=MANHATTAN     --BK heights sliver, no
-# --11207=QUEENS        --border sliver no
-# --11208=QUEENS        --border sliver no
-# --11211=MANHATTAN     --east river sliver slop, no
-# --11222=MANHATTAN     --east river sliver slop, no
-# --11231=MANHATTAN     --east river sliver slop, no
-# --11237=QUEENS        --border sliver no
-# --11351=QUEENS        --real PO in Flushing, YES
-# --11370=BRONX         --Rikers issue again, no
-# --11378=BROOKLYN      --Border sliver no
-# --11385=BROOKLYN      --Border sliver no
-# --11414=BROOKLYN      --Border sliver no
-# --11416=BROOKLYN      --Border sliver no
-# --11417=BROOKLYN      --Border sliver no
-# --11421=BROOKLYN      --Border sliver no
-# --11424=QUEENS        --Real PO in Jamaica, YES
-# --11425=BROOKLYN      --Census says southern BK, USPS Jamaica, gonna go no
-# --11559=QUEENS        --Nassau sliver, no
-# --11580=QUEENS        --Nassau sliver, no
-# --11581=QUEENS        --Nassau sliver, no

--- a/geoclient-parser/src/main/resources/zip.properties
+++ b/geoclient-parser/src/main/resources/zip.properties
@@ -1,15 +1,9 @@
-#
-# 2014-02-25
-# Generated from geoserver@GEOCPRD query:
-# SELECT zipcode||'='||DECODE(county, 'New York','MANHATTAN','Bronx','BRONX','Kings', 'BROOKLYN','Queens', 'QUEENS','Richmond','STATEN ISLAND') AS borough FROM zip_code ORDER BY 1;
-# 
 00083=MANHATTAN
+07305=MANHATTAN
+10000=MANHATTAN
 10001=MANHATTAN
 10002=MANHATTAN
 10003=MANHATTAN
-10004=MANHATTAN
-10004=MANHATTAN
-10004=MANHATTAN
 10004=MANHATTAN
 10005=MANHATTAN
 10006=MANHATTAN
@@ -40,7 +34,6 @@
 10033=MANHATTAN
 10034=MANHATTAN
 10035=MANHATTAN
-10035=MANHATTAN
 10036=MANHATTAN
 10037=MANHATTAN
 10038=MANHATTAN
@@ -50,7 +43,6 @@
 10043=MANHATTAN
 10044=MANHATTAN
 10045=MANHATTAN
-10047=MANHATTAN
 10047=MANHATTAN
 10048=MANHATTAN
 10055=MANHATTAN
@@ -99,7 +91,7 @@
 10177=MANHATTAN
 10178=MANHATTAN
 10196=MANHATTAN
-10196=MANHATTAN
+10199=MANHATTAN
 10203=MANHATTAN
 10259=MANHATTAN
 10260=MANHATTAN
@@ -124,7 +116,9 @@
 10308=STATEN ISLAND
 10309=STATEN ISLAND
 10310=STATEN ISLAND
+10311=STATEN ISLAND
 10312=STATEN ISLAND
+10313=STATEN ISLAND
 10314=STATEN ISLAND
 10451=BRONX
 10452=BRONX
@@ -139,9 +133,6 @@
 10461=BRONX
 10462=BRONX
 10463=BRONX
-10463=MANHATTAN
-10464=BRONX
-10464=BRONX
 10464=BRONX
 10465=BRONX
 10466=BRONX
@@ -158,7 +149,6 @@
 11004=QUEENS
 11005=QUEENS
 11040=QUEENS
-11096=QUEENS
 11096=QUEENS
 11101=QUEENS
 11102=QUEENS
@@ -196,7 +186,6 @@
 11229=BROOKLYN
 11230=BROOKLYN
 11231=BROOKLYN
-11231=BROOKLYN
 11232=BROOKLYN
 11233=BROOKLYN
 11234=BROOKLYN
@@ -207,6 +196,7 @@
 11239=BROOKLYN
 11249=BROOKLYN
 11251=BROOKLYN
+11351=QUEENS
 11354=QUEENS
 11355=QUEENS
 11356=QUEENS
@@ -223,7 +213,6 @@
 11367=QUEENS
 11368=QUEENS
 11369=QUEENS
-11370=BRONX
 11370=QUEENS
 11371=QUEENS
 11372=QUEENS
@@ -247,6 +236,7 @@
 11421=QUEENS
 11422=QUEENS
 11423=QUEENS
+11424=QUEENS
 11426=QUEENS
 11427=QUEENS
 11428=QUEENS
@@ -260,9 +250,270 @@
 11451=QUEENS
 11691=QUEENS
 11692=QUEENS
-11693=BROOKLYN
-11693=QUEENS
-11693=QUEENS
 11693=QUEENS
 11694=QUEENS
+11695=QUEENS
 11697=QUEENS
+#
+# -- 1. Remove duplicate zipcode=borough key values
+# --    Reduces 263 pairs to 251
+# --    We are left with 3 zips that cross boroughs and should be ogled
+# --    10463=(BRONX|MANHATTAN) A bit of Marble Hill. Give to BX where most of zip is
+# --    11370=(BRONX|QUEENS)  Rikers island, zip is predominantly in Queens
+# --    11693=(BROOKLYN|QUEENS) This is Queens in Jamaica Bay, typical GIS shenanigans
+#
+# with zip_properties_geoclient as (
+#    select '00083=MANHATTAN' as keyval from dual union
+#    select '10001=MANHATTAN' from dual union
+#    select '10002=MANHATTAN' from dual union
+# SNIP!
+#    select '11693=QUEENS' from dual union
+#    select '11694=QUEENS' from dual union
+#    select '11697=QUEENS' from dual
+# ) select distinct keyval
+#  from
+#        zip_properties_geoclient
+#  order by 1;
+#
+#   -- 2. NYC Street Centerline (CSCL) database comparison using cscl_pub.zipcode
+#   --    Yields nothing new, appears to be the same dataset that produced the
+#   -     original geoclient parser info
+#
+# with keyvals as (
+#    select '00083=MANHATTAN' as keyval from dual union
+#    select '10001=MANHATTAN' from dual union
+#    select '10002=MANHATTAN' from dual union
+# SNIP!
+#    select '11694=QUEENS' from dual union
+#    select '11697=QUEENS' from dual
+# ) select keyval
+#    from
+#        keyvals
+#    minus
+#    select distinct to_char(zip_code) || '=' || DECODE(county, 'New York','MANHATTAN','Bronx','BRONX','Kings', 'BROOKLYN','Queens', 'QUEENS','Richmond','STATEN ISLAND') AS keyval
+#    from
+#        cscl_pub.zipcode
+#union
+#    select to_char(zip_code) || '=' || DECODE(county, 'New York','MANHATTAN','Bronx','BRONX','Kings', 'BROOKLYN','Queens', 'QUEENS','Richmond','STATEN ISLAND') AS keyval
+#    from
+#        cscl_pub.zipcode
+#    minus
+#    select keyval
+#    from
+#        keyvals;
+#
+# -- 3. Compare to all address points in CSCL
+# --    Yields 35 zip codes in geoclient properties that have no address point
+# --    34 are Manhattan Post Offices, all good, keep these
+# --    1 is the duplicate 11693=BROOKLYN This is a Queens zip code in
+# --    in Jamaica Bay that through typical GIS shenanigans, turning non-spatial
+# --    Zip codes into shapes results in some slopping into Brooklyn
+# --    11693=BROOKLYN - you are officially voted off the island
+# --
+# with keyvals as (
+#    select '00083=MANHATTAN' as keyval from dual union
+#    select '10001=MANHATTAN' from dual union
+# SNIP!
+#    select '11694=QUEENS' from dual union
+#    select '11697=QUEENS' from dual
+# ) select distinct TO_CHAR(zipcode) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval
+#     from
+#         cscl_pub.ADDRESSPOINT
+#     minus
+#     select keyval
+#     from
+#         keyvals
+# union
+#     select keyval
+#     from
+#         keyvals
+#     minus
+#     select distinct TO_CHAR(zipcode) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval
+#     from
+#         cscl_pub.ADDRESSPOINT;
+# --10041=MANHATTAN
+# --10043=MANHATTAN
+# --10045=MANHATTAN
+# --10047=MANHATTAN
+# --10103=MANHATTAN
+# --10104=MANHATTAN
+# --10105=MANHATTAN
+# --10110=MANHATTAN
+# --10112=MANHATTAN
+# --10119=MANHATTAN
+# --10120=MANHATTAN
+# --10122=MANHATTAN
+# --10123=MANHATTAN
+# --10151=MANHATTAN
+# --10155=MANHATTAN
+# --10158=MANHATTAN
+# --10162=MANHATTAN
+# --10165=MANHATTAN
+# --10166=MANHATTAN
+# --10167=MANHATTAN
+# --10169=MANHATTAN
+# --10170=MANHATTAN
+# --10171=MANHATTAN
+# --10172=MANHATTAN
+# --10173=MANHATTAN
+# --10174=MANHATTAN
+# --10175=MANHATTAN
+# --10176=MANHATTAN
+# --10177=MANHATTAN
+# --10178=MANHATTAN
+# --10203=MANHATTAN
+# --10271=MANHATTAN
+# --10285=MANHATTAN
+# --10286=MANHATTAN
+# --11693=BROOKLYN
+#
+# -- 4. Compare to all L_ZIP and R_ZIP in CSCL centerlines
+# --    Yields 3 new zips (Fresh Kills, Central Park, Fort Tilden)
+# --    And some detailed notes on questionable zip codes that I guess we should
+# --    keep.
+# -- First, these exist in CSCL centerlines, not in Geoclient parser
+# with keyvals as (
+#   select '00083=MANHATTAN' as keyval from dual union
+#   select '10001=MANHATTAN' from dual union
+# SNIP!
+#   select '11694=QUEENS' from dual union
+#   select '11697=QUEENS' from dual
+# )
+#  select keyval from (
+#      select distinct TO_CHAR(l_zip) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval from cscl_pub.CENTERLINE where l_zip is not null
+#      union
+#      select distinct TO_CHAR(r_zip) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval from cscl_pub.CENTERLINE where r_zip is not null
+# )
+# minus
+#  select keyval
+#       from keyvals;
+#-- exist in centerline not in geoclient
+#-- lets review these and add some to the geoclient parser!
+#--10000=MANHATTAN     -- Central Park! This is not a real zip code, like 00083. YES ADD
+#--10035=BRONX         -- Tiny segment of third ave bike bridge, rest of 10035 in MN. NO
+#--10037=BRONX         -- Large segment of third ave bike bridge, rest of 10035 in MN. NO
+#--10313=STATEN ISLAND -- Fresh Kills landfill. A real zip code.  OH YES ADD
+#--10400=BRONX         -- A few segments at the entrance of Rikers. Not a real zip code. No
+#--10451=MANHATTAN     -- 145 ST Bridge segment, rest of zip is in BX. No
+#--10453=MANHATTAN     -- A few segments of Washington St, rest of Zip in BX. No
+#--10454=MANHATTAN     -- A segment of Willis St, rest of Zip in BX. No
+#--11201=MANHATTAN     -- Greenway in Brooklyn Bridge Park.  It is technically in MN but the zip is BK. No
+#--11222=QUEENS        -- Bit of Pulaski Bridge.  Zip is in BK. No
+#--11234=QUEENS        -- Bit of Marine Parkway Bridge.  Zip is in BK. No
+#--11239=QUEENS        -- Bit of Belt Parkway. Zip is in BK. No
+#--11249=MANHATTAN     -- Bit of Williamsburg bridge.  Zip is in BK. No.
+#--11385=BROOKLYN      -- A few Ridgewood-adjacent alleys.  Zip in Queens. No
+#--11396=QUEENS        -- Not a real zip code.  Should be 113_69_. Nice, but no.
+#--11416=BROOKLYN      -- Segments on near Ozone Park border. Zip is in QN. No
+#--11693=BROOKLYN      -- This is that dumb Far Rockaway segment that GISed into BK. No
+#--11695=QUEENS        -- Fort Tilden, oh YES
+#
+# These exist in Geoclient parser, not in CSCL centerlines. All are OK
+# with keyvals as (
+#    select '00083=MANHATTAN' as keyval from dual union
+#    select '10001=MANHATTAN' from dual union
+# SNIP!
+#    select '11694=QUEENS' from dual union
+#    select '11697=QUEENS' from dual
+# )
+# select keyval
+#    from keyvals
+# minus
+# select keyval from (
+#     select distinct TO_CHAR(l_zip) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval from cscl_pub.CENTERLINE where l_zip is not null
+#     union
+#     select distinct TO_CHAR(r_zip) || '=' || DECODE(boroughcode, 1,'MANHATTAN',2,'BRONX',3, 'BROOKLYN',4, 'QUEENS',5,'STATEN ISLAND') AS keyval from cscl_pub.CENTERLINE where r_zip is not null
+# )
+#--
+#-- exist in geoclient not in centerline
+#--
+#--10043=MANHATTAN --Real PO in MN, OK
+#--10047=MANHATTAN --Non existent zip code, overlaps 10010.  But its pervasive in CSCL-derived products. OK
+#--10055=MANHATTAN --Real PO in MN. OK
+#--10081=MANHATTAN --Real PO in MN. OK
+#--10096=MANHATTAN --Non existent zip code. But its possibly pervasive in CSCL-derived products. OK
+#--10097=MANHATTAN --Non existent zip code. But its been pervasive. OK
+#--10104=MANHATTAN --Real PO in MN. OK
+#--10107=MANHATTAN --Real PO in MN. OK
+#--10115=MANHATTAN --Real PO in MN. OK
+#--10122=MANHATTAN --Real PO in MN. OK
+#--10123=MANHATTAN --Real PO in MN. OK
+#--10151=MANHATTAN --Real PO in MN. OK
+#--10153=MANHATTAN --Real PO in MN. OK
+#--10168=MANHATTAN --Real PO in MN. OK
+#--10169=MANHATTAN --Real PO in MN. OK
+#--10196=MANHATTAN --Non existent zip code. But its presumably pervasive. OK
+#--10203=MANHATTAN --Real PO in MN. OK
+#--10259=MANHATTAN --Real PO in MN. OK
+#--10260=MANHATTAN --Real PO in MN. OK
+#--10265=MANHATTAN --Real PO in MN. OK
+#--10270=MANHATTAN --Real PO in MN. OK
+#--10275=MANHATTAN --Real PO in MN. OK
+#--10285=MANHATTAN --Real PO in MN. OK
+#--10286=MANHATTAN --Real PO in MN. OK
+#--11096=QUEENS    --Territory in Far Rockaway that possibly uses a Nassau County zip
+#--11451=QUEENS    --York College, OK
+#
+# --5. Get Zip Code Tabulation Areas and see what we get
+# --     https://www2.census.gov/geo/tiger/TIGER2019/
+# --     https://data.cityofnewyork.us/City-Government/Borough-Boundaries/tqmj-j8zm
+# --     upload as sdo_geometry to master@giscmnt
+# -- Get ZCTA=BOROUGH combos that exist in census but not in Geoclient Parser
+#
+#select to_char(a.zcta5ce10) || '=' || UPPER(b.boroname), sdo_geom.relate(a.shape, 'mask=determine', b.shape, .0005)
+# with keyvals as
+#   (select '00083=MANHATTAN' as keyval from dual union
+#    select '10000=MANHATTAN' from dual union
+# SNIP!
+#    select '11695=QUEENS' from dual union
+#    select '11697=QUEENS' from dual)
+# select keyval from (
+#     select to_char(a.zcta5ce10) || '=' || to_char(UPPER(b.boroname)) as keyval
+#     from
+#        zctas a
+#       ,nybb b
+#     where
+#        sdo_relate(a.shape
+#                  ,b.shape
+#                  ,'mask=INSIDE+COVEREDBY+OVERLAPBDYINTERSECT+OVERLAPBDYDISJOINT') = 'TRUE'
+# )
+# minus
+# select to_char(keyval)
+# from
+#     keyvals;
+# --07002=STATEN ISLAND --NJ sliver bordering staten island, no
+# --07206=STATEN ISLAND --NJ sliver bordering staten island, no
+# --07305=MANHATTAN     --NJ zip that jokers in NJ will claim on Ellis Island. YES
+# --10004=BROOKLYN      --Roosevelt island sliver, no
+# --10199=MANHATTAN     --A real PO in MN.  YES
+# --10311=STATEN ISLAND --More Fresh Kills. YES
+# --10463=MANHATTAN     --Marble Hill, no
+# --10550=BRONX         --Westchester sliver, no
+# --10704=BRONX         --Westchester sliver, no
+# --10705=BRONX         --Westchester sliver, no
+# --10803=BRONX         --Westchester sliver, no
+# --11003=QUEENS        --Nassau sliver, no
+# --11020=QUEENS        --Nassau sliver, no
+# --11021=QUEENS        --Nassau sliver, no
+# --11042=QUEENS        --Nassau sliver, no
+# --11102=MANHATTAN     --Queens sliver Astoria, no
+# --11201=MANHATTAN     --BK heights sliver, no
+# --11207=QUEENS        --border sliver no
+# --11208=QUEENS        --border sliver no
+# --11211=MANHATTAN     --east river sliver slop, no
+# --11222=MANHATTAN     --east river sliver slop, no
+# --11231=MANHATTAN     --east river sliver slop, no
+# --11237=QUEENS        --border sliver no
+# --11351=QUEENS        --real PO in Flushing, YES
+# --11370=BRONX         --Rikers issue again, no
+# --11378=BROOKLYN      --Border sliver no
+# --11385=BROOKLYN      --Border sliver no
+# --11414=BROOKLYN      --Border sliver no
+# --11416=BROOKLYN      --Border sliver no
+# --11417=BROOKLYN      --Border sliver no
+# --11421=BROOKLYN      --Border sliver no
+# --11424=QUEENS        --Real PO in Jamaica, YES
+# --11425=BROOKLYN      --Census says southern BK, USPS Jamaica, gonna go no
+# --11559=QUEENS        --Nassau sliver, no
+# --11580=QUEENS        --Nassau sliver, no
+# --11581=QUEENS        --Nassau sliver, no


### PR DESCRIPTION
I started with these assumptions:

1. Assumption: Duplicate zip codes are not helpful.  This includes both 

    123456=MANHATTAN
    123456=MANHATTAN

    and also 

    123456=MANHATTAN
    123456=BRONX
    
     Where the zip code primarily belongs to a single borough, the secondary borough is not helpful.

2. Assumption: More zip codes are better than fewer zip codes.  So when in doubt about whether a zip code might actually be in use, I added it and its associated borough.

Using these assumptions I:

1. Removed all duplicates

2. Compared geoclient zip code=borough combos to CSCL zip codes (yielded nothing)

3. Compared geoclient zip code=borough combos to CSCL address points (helped remove some dupes)

4. Compared geoclient zip code=borough combos to CSCL centerline L_ZIP and R_ZIP values. Yielded 3 new zip codes

5. Compared geoclient zip code=borough combos to 2019 Census Zip Code Tabulation Areas. Yielded 5 new zip codes.

I show my work in way too many commented lines at the end of the properties file.  If this is TMI feel free to kick this back to me and I'll offload my notes to somewhere else (let me know)
    